### PR TITLE
chore: change migration name and users table schema

### DIFF
--- a/commands/Setup.js
+++ b/commands/Setup.js
@@ -24,10 +24,10 @@ class AuthSetup extends Command {
   }
 
   * handle () {
-    this.run('make:migration', 'User', {template: path.join(__dirname, './templates/userSchema.mustache')})
-    this.run('make:migration', 'Token', {template: path.join(__dirname, './templates/tokenSchema.mustache')})
-    this.run('make:model', 'User', {template: path.join(__dirname, './templates/userModel.mustache')})
-    this.run('make:model', 'Token', {template: path.join(__dirname, './templates/tokenModel.mustache')})
+    this.run('make:migration', 'create_users_table', { template: path.join(__dirname, './templates/userSchema.mustache') })
+    this.run('make:migration', 'create_tokens_table', { template: path.join(__dirname, './templates/tokenSchema.mustache') })
+    this.run('make:model', 'User', { template: path.join(__dirname, './templates/userModel.mustache') })
+    this.run('make:model', 'Token', { template: path.join(__dirname, './templates/tokenModel.mustache') })
   }
 
 }

--- a/commands/templates/tokenSchema.mustache
+++ b/commands/templates/tokenSchema.mustache
@@ -2,10 +2,10 @@
 
 const Schema = use('Schema')
 
-class TokenSchema extends Schema {
+class TokensTableSchema extends Schema {
 
   up () {
-    this.create('tokens', (table) => {
+    this.create('tokens', table => {
       table.increments()
       table.integer('user_id').unsigned().references('id').inTable('users')
       table.string('token', 40).notNullable().unique()

--- a/commands/templates/userSchema.mustache
+++ b/commands/templates/userSchema.mustache
@@ -2,16 +2,14 @@
 
 const Schema = use('Schema')
 
-class UserSchema extends Schema {
+class UsersTableSchema extends Schema {
 
   up () {
-    this.create('users', (table) => {
+    this.create('users', table => {
       table.increments()
       table.string('username', 80).notNullable().unique()
       table.string('email', 254).notNullable().unique()
       table.string('password', 60).notNullable()
-      table.string('firstname')
-      table.string('lastname')
       table.timestamps()
     })
   }


### PR DESCRIPTION
1. I have renamed the migration file to `create_xxx_table`. This is more descriptive and better, especially if I want to add a field to the User table after.

2. I have renamed the class of the migration. It seems more correct to me (it's the table schema). I'll send another PR if this is merged to add this suffix into the generator.

3. I have removed two field into the user's table because `firstname` and `lastname` are not in the default seeder and this should be not added by default.