### PR TITLE
Custom JWT payload

### DIFF
--- a/test/integration/jwt.spec.js
+++ b/test/integration/jwt.spec.js
@@ -106,7 +106,7 @@ describe('Authenticators', function () {
           res.end()
         })
       })
-      const jwtToken = jwt.sign({payload: 2}, 'bubblegum')
+      const jwtToken = jwt.sign({samsepi0l: 2}, 'bubblegum')
       const response = yield supertest(server).get('/').set('Authorization', `Bearer ${jwtToken}`)
       expect(response.body).to.equal(true)
     })

--- a/test/integration/setup/index.js
+++ b/test/integration/setup/index.js
@@ -38,7 +38,8 @@ const jwtConfig = {
   serializer: 'Lucid',
   model: DummyModel,
   scheme: 'jwt',
-  secret: 'bubblegum'
+  secret: 'bubblegum',
+  userKey: 'samsepi0l'
 }
 
 const Config = {

--- a/test/unit/authenticators/jwt.spec.js
+++ b/test/unit/authenticators/jwt.spec.js
@@ -26,6 +26,7 @@ const Config = function (model, options) {
     password: 'password',
     scheme: 'jwt',
     secret: 'bubblegum',
+    userKey: 'Wh1teR0se',
     options: options
   }
 }
@@ -101,7 +102,9 @@ describe('Authenticators', function () {
       }
       const request = {
         header: function () {
-          return 'Bearer ' + jwt.sign({payload: 1}, Config(User).secret)
+          const payload = {};
+          payload[Config(User).userKey] = 1;
+          return 'Bearer ' + jwt.sign(payload, Config(User).secret)
         }
       }
       sinon.spy(User, 'find')
@@ -123,7 +126,9 @@ describe('Authenticators', function () {
       }
       const request = {
         header: function () {
-          return 'Bearer ' + jwt.sign({payload: 1}, Config(User).secret)
+          const payload = {};
+          payload[Config(User).userKey] = 1;
+          return 'Bearer ' + jwt.sign(payload, Config(User).secret)
         }
       }
       sinon.spy(User, 'find')
@@ -149,7 +154,9 @@ describe('Authenticators', function () {
           return null
         },
         input: function () {
-          return jwt.sign({payload: 1}, Config(User).secret)
+          const payload = {};
+          payload[Config(User).userKey] = 1;
+          return jwt.sign(payload, Config(User).secret)
         }
       }
       sinon.spy(User, 'find')
@@ -172,7 +179,9 @@ describe('Authenticators', function () {
       }
       const request = {
         header: function () {
-          return 'Bearer ' + jwt.sign({payload: 1}, Config(User).secret)
+          const payload = {};
+          payload[Config(User).userKey] = 1;
+          return 'Bearer ' + jwt.sign(payload, Config(User).secret)
         }
       }
       const jwtAuth = new JwtScheme(request, this.serializer, Config(User))
@@ -220,7 +229,7 @@ describe('Authenticators', function () {
       }
       const jwtAuth = new JwtScheme(request, this.serializer, Config(User))
       const token = yield jwtAuth.generate({id: 1})
-      expect(jwt.verify(token, Config(User).secret).payload).to.equal(1)
+      expect(jwt.verify(token, Config(User).secret)[Config(User).userKey]).to.equal(1)
     })
 
     it('should be able to define issuer while generating a token', function * () {
@@ -232,7 +241,7 @@ describe('Authenticators', function () {
       const jwtAuth = new JwtScheme(request, this.serializer, Config(User, {issuer: 'adonisjs.com'}))
       const token = yield jwtAuth.generate({id: 1})
       const decoded = jwt.verify(token, Config(User).secret)
-      expect(decoded.payload).to.equal(1)
+      expect(decoded[Config(User).userKey]).to.equal(1)
       expect(decoded.iss).to.equal('adonisjs.com')
     })
 
@@ -330,7 +339,7 @@ describe('Authenticators', function () {
       sinon.spy(User, 'first')
       const token = yield sessionAuth.attempt('foo@bar.com', 'secret')
       const decoded = jwt.verify(token, Config(User).secret)
-      expect(decoded.payload).to.equal(1)
+      expect(decoded[Config(User).userKey]).to.equal(1)
       User.query.restore()
       User.where.restore()
       User.first.restore()


### PR DESCRIPTION
Oh maaan, didn't notice that there is already a PR for that. However I still think this is more complete solution than the other for the reasons below. You decide. :)

This PR adds an ability to pass an object to JWT authenticator so that you can store in your token necessary information.

The existing `payload` key is replaced by custom key defined in the authenticator's configuration `userKey`. As _payload_ says nothing about what it stores it seemed reasonable to make it configurable and what's more some scenarios may require storing user ID under specific key.

`generate` method gets second argument which is raw object which is gonna be the token's payload. It doesn't change the existing behaviour so any static data specified in `options` key in JWT's configuration will be still there.

`attempt` method gets third argument which is a function receiving a user on which you can base your token's payload. The function should return an object which goes straight to the `generate` method (see above). For example you can put there user roles.

If this goes through it will be mandatory to include `userKey: 'payload'` in the default JWT configuration. Defaulting it to `payload` in the code is more hacky than introducing new configuration variable. Also it won't change anything in the existing codebases so if you don't bother about custom payload you don't have to do anything.

I'll be happy to see suggestions on how to make it better.
