### PR TITLE
Resolves adonisjs/adonis-framework #223.

### DIFF
--- a/src/Serializers/Lucid/index.js
+++ b/src/Serializers/Lucid/index.js
@@ -181,12 +181,12 @@ class LucidSerializer {
    * @public
    */
   * revokeTokens (user, tokens, reverse) {
-    const userTokens = user.apiTokens().query()
+    const userTokens = user.apiTokens()
     if (tokens) {
       const method = reverse ? 'whereNotIn' : 'whereIn'
       userTokens[method]('token', tokens)
     }
-    return yield userTokens.update('is_revoked', true)
+    return yield userTokens.update({'is_revoked': true})
   }
 
   /**


### PR DESCRIPTION
https://github.com/adonisjs/adonis-framework/issues/223 Issue with Revoking All Tokens.

Resolves errors: 

TypeError: user.apiTokens(...).query is not a function

TypeError: Cannot create property 'updated_at' on string 'is_revoked'