### PR TITLE
Fix getUser return null if auth is not default

### DIFF
--- a/middleware/Auth.js
+++ b/middleware/Auth.js
@@ -40,7 +40,7 @@ class Auth {
         result = yield request.auth.authenticator(authenticator).check()
       }
       if (result) {
-        request.authUser = yield request.auth.getUser()
+        request.authUser = yield request.auth.authenticator(authenticator).getUser()
         /**
          * we need to break the loop as soon as an authenticator
          * returns true. Ideally one cannot break promises chain


### PR DESCRIPTION
configure in config/auth.js: `authenticator: 'jwt',`
put auth middleware to route `middleware('auth:jwt,basic,api')`
only request with jwt can get currentUser object, other ways will get null
This PR will fix this issue