### PR TITLE
Updating jwt.Attempt() to accept custom payload

### DIFF
--- a/src/Schemes/Jwt/index.js
+++ b/src/Schemes/Jwt/index.js
@@ -145,9 +145,13 @@ class JwtScheme extends BaseScheme {
    *
    * @return {String}
    */
-  * attempt (uid, password) {
+  * attempt (uid, password, customPayload) {
+    let payload = null
     const user = yield this.validate(uid, password, true)
-    return yield this.generate(user)
+    if (customPayload) {
+      payload = typeof (customPayload.toJSON) === 'function' ? customPayload.toJSON() : customPayload
+    }
+    return yield (payload !== null) ? this.generate(user, payload) : this.generate(user)
   }
 
 }


### PR DESCRIPTION
As per the issue I opened up in adonisjs/adonis-auth/issues/38, this is a small PR to change the JWT `attempt()` method to accept an optional payload object.