### PR TITLE
Using uuid.v4() instead of uuid.v1()

### DIFF
--- a/src/Schemes/Api/index.js
+++ b/src/Schemes/Api/index.js
@@ -74,7 +74,7 @@ class ApiScheme extends BaseScheme {
     }
     expiry = expiry || this.options.expiry
     expiry = expiry ? ms(expiry) : null
-    const token = uuid.v1().replace(/-/g, '')
+    const token = uuid.v4().replace(/-/g, '')
     return yield this.serializer.saveToken(user, token, this.options, expiry)
   }
 


### PR DESCRIPTION
The generate method modified in this change seems to be what is generating API (and session?) tokens. If this is the case, then I believe that using the v4() method instead of v1() would be more desirable as it would provide higher entropy and so be harder to reproduce. v4() is completely random while v1() is time-based.