### PR TITLE
Add a cookie fallback in getAuthHeader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adonisjs/auth",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12,7 +12,6 @@
       "requires": {
         "@adonisjs/generic-exceptions": "1.0.0",
         "caller": "1.0.1",
-        "debug": "2.6.8",
         "lodash": "4.17.4",
         "require-stack": "1.0.2"
       }
@@ -33,7 +32,6 @@
       "dev": true,
       "requires": {
         "@adonisjs/generic-exceptions": "1.0.0",
-        "debug": "2.6.8",
         "knex": "0.13.0",
         "lodash": "4.17.4",
         "moment": "2.18.1",
@@ -575,9 +573,9 @@
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -839,7 +837,6 @@
         "babel-code-frame": "6.22.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.8",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
         "espree": "3.4.3",
@@ -908,7 +905,6 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
         "object-assign": "4.1.1",
         "resolve": "1.4.0"
       }
@@ -919,7 +915,6 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
         "pkg-dir": "1.0.0"
       }
     },
@@ -931,7 +926,6 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.8",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.2.3",
         "eslint-module-utils": "2.1.1",
@@ -1475,7 +1469,8 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -1738,11 +1733,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1796,17 +1786,6 @@
         "commander": "2.11.0",
         "globby": "6.1.0",
         "left-pad": "1.1.3"
-      }
-    },
-    "joi": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-      "requires": {
-        "hoek": "2.16.3",
-        "isemail": "1.2.0",
-        "moment": "2.18.1",
-        "topo": "1.1.0"
       }
     },
     "js-tokens": {
@@ -1875,12 +1854,17 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.1.tgz",
-      "integrity": "sha1-fKMk9SFfi+A5zTWmxFu4y3SkSPs=",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+      "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
       "requires": {
-        "joi": "6.10.1",
         "jws": "3.1.4",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
         "lodash.once": "4.1.1",
         "ms": "2.0.0",
         "xtend": "4.0.1"
@@ -1952,7 +1936,6 @@
         "bluebird": "3.5.0",
         "chalk": "1.1.3",
         "commander": "2.11.0",
-        "debug": "2.6.8",
         "generic-pool": "2.5.4",
         "inherits": "2.0.3",
         "interpret": "0.6.6",
@@ -2043,6 +2026,36 @@
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -2165,7 +2178,8 @@
     "moment": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -5649,7 +5663,6 @@
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
-        "debug": "2.6.8",
         "extend": "3.0.1",
         "form-data": "2.1.4",
         "formidable": "1.1.1",
@@ -5776,14 +5789,6 @@
       "dev": true,
       "requires": {
         "user-home": "1.1.1"
-      }
-    },
-    "topo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "requires": {
-        "hoek": "2.16.3"
       }
     },
     "tough-cookie": {

--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -184,7 +184,7 @@ class BaseScheme {
     /**
      * Fallback to cookie
      */
-     return request.cookie('adonis-auth-jwt')
+    return request.cookie('adonis-auth-jwt')
   }
 }
 

--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -176,7 +176,15 @@ class BaseScheme {
     /**
      * Fallback to `input` field
      */
-    return request.input('token', null)
+    token = request.input('token', null)
+    if (token) {
+      return token
+    }
+
+    /**
+     * Fallback to cookie
+     */
+     return request.cookie('adonis-auth-jwt')
   }
 }
 


### PR DESCRIPTION
The getAuthHeader method currently implements a fallback to request.input('token') if an authorization header is not set. I just add a second fallback to read the jwt from a cookie if neither an authorization header nor a token body are set.

This commit permit to store the jwt in a http-only cookie in order to avoid exposing jwt to js and thereby reduce xss attacks possibilities.