### PR TITLE
Add a cookie fallback in getAuthHeader

### DIFF
--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -185,7 +185,7 @@ class BaseScheme {
     /**
      * Fallback to cookie
      */
-    return request.cookie('adonis-auth-jwt')
+    return request.cookie('adonis-auth-jwt', null)
   }
 }
 

--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -156,7 +156,7 @@ class BaseScheme {
   /**
    * Returns the value of authorization header
    * or request payload token key value
-   * or 'adonis-auth-jwt' cookie value
+   * or 'adonis-auth-token' cookie value
    *
    * @method getAuthHeader
    *
@@ -185,7 +185,7 @@ class BaseScheme {
     /**
      * Fallback to cookie
      */
-    return request.cookie('adonis-auth-jwt', null)
+    return request.cookie('adonis-auth-token', null)
   }
 }
 

--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -156,6 +156,7 @@ class BaseScheme {
   /**
    * Returns the value of authorization header
    * or request payload token key value
+   * or 'adonis-auth-jwt' cookie value
    *
    * @method getAuthHeader
    *
@@ -176,7 +177,15 @@ class BaseScheme {
     /**
      * Fallback to `input` field
      */
-    return request.input('token', null)
+    token = request.input('token', null)
+    if (token) {
+      return token
+    }
+
+    /**
+     * Fallback to cookie
+     */
+    return request.cookie('adonis-auth-jwt')
   }
 }
 

--- a/test/unit/api-scheme.spec.js
+++ b/test/unit/api-scheme.spec.js
@@ -274,6 +274,9 @@ test.group('Schemes - Api', (group) => {
         },
         input () {
           return null
+        },
+        cookie () {
+          return null
         }
       }
     })


### PR DESCRIPTION
The getAuthHeader method currently implements a fallback to request.input('token') if an authorization header is not set. I just add a second fallback to read the jwt from a cookie if neither an authorization header nor a token body are set.

This commit permit to store the jwt in a http-only cookie in order to avoid exposing jwt to js and thereby reduce xss attacks possibilities.