### PR TITLE
feat(jwt): add login() method to jwt scheme

### DIFF
--- a/src/Schemes/Jwt.js
+++ b/src/Schemes/Jwt.js
@@ -208,21 +208,14 @@ class JwtScheme extends BaseScheme {
   }
 
   /**
-   * Generates a jwt token for a user
-   *
-   * This method acts as alias fot `generate()`,
-   * it's also a compatibility layer for `Auth.login()` method.
-   *
    * @method login
-   *
-   * @param {Object} user
-   *
-   * @return {Object}
    *
    * @throws {RuntimeException} If jwt secret is not defined or user doesn't have a primary key value
    */
-  login (user) {
-    return this.generate(user)
+  login () {
+    throw GE
+      .RuntimeException
+      .invoke('method not implemented, use generate() to retrieve jwt token', 500, 'E_CANNOT_LOGIN')
   }
 
   /**

--- a/src/Schemes/Jwt.js
+++ b/src/Schemes/Jwt.js
@@ -210,6 +210,24 @@ class JwtScheme extends BaseScheme {
   /**
    * Generates a jwt token for a user
    *
+   * This method acts as alias fot `generate()`,
+   * it's also a compatibility layer for `Auth.login()` method.
+   *
+   * @method login
+   *
+   * @param {Object} user
+   *
+   * @return {Object}
+   *
+   * @throws {RuntimeException} If jwt secret is not defined or user doesn't have a primary key value
+   */
+  login (user) {
+    return this.generate(user)
+  }
+
+  /**
+   * Generates a jwt token for a user
+   *
    * @method generate
    * @async
    *

--- a/test/unit/jwt-scheme.spec.js
+++ b/test/unit/jwt-scheme.spec.js
@@ -779,6 +779,32 @@ test.group('Schemes - Jwt', (group) => {
     assert.equal(iss, 'adonisjs')
   })
 
+  test('generate token via login() method', async (assert) => {
+    assert.plan(1)
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password',
+      options: {
+        secret: SECRET
+      }
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    const user = await User.create({ email: 'foo@bar.com', password: 'secret' })
+
+    const jwt = new Jwt(Encryption)
+    jwt.setOptions(config, lucid)
+
+    const { token } = await jwt.login(user)
+    const { uid } = await verifyToken(token)
+    assert.equal(uid, 1)
+  })
+
   test('list refresh tokens', async (assert) => {
     const User = helpers.getUserModel()
 

--- a/test/unit/jwt-scheme.spec.js
+++ b/test/unit/jwt-scheme.spec.js
@@ -779,7 +779,7 @@ test.group('Schemes - Jwt', (group) => {
     assert.equal(iss, 'adonisjs')
   })
 
-  test('generate token via login() method', async (assert) => {
+  test('throw exception when calling login()', async (assert) => {
     assert.plan(1)
     const User = helpers.getUserModel()
 
@@ -800,9 +800,11 @@ test.group('Schemes - Jwt', (group) => {
     const jwt = new Jwt(Encryption)
     jwt.setOptions(config, lucid)
 
-    const { token } = await jwt.login(user)
-    const { uid } = await verifyToken(token)
-    assert.equal(uid, 1)
+    try {
+      jwt.login(user)
+    } catch ({ message }) {
+      assert.equal(message, 'E_CANNOT_LOGIN: method not implemented, use generate() to retrieve jwt token')
+    }
   })
 
   test('list refresh tokens', async (assert) => {


### PR DESCRIPTION
When using `Jwt` scheme `auth.login(user)` fails.
It's due to lack of such method in `Schemes/Jwt`. 

This PR introduces `login()` method which is an alias for `generate()`.
