### PR TITLE
Added support for Plain API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Adonisjs auth is an authentication provider to add authentication layer to your 
 
 ## What's in the box?
 
-1. Support for multiple authentication schemes like **Jwt**, **Sessions**, **Basic auth** and **Personal API tokens**.
+1. Support for multiple authentication schemes like **Jwt**, **Sessions**, **Basic auth**, **Personal API tokens** and **Plain API tokens**.
 2. Support for Lucid and Database serializer.
 3. Easy to extend API to add your own serializers and schemes.
 4. Runtime middleware.

--- a/instructions.js
+++ b/instructions.js
@@ -28,6 +28,10 @@ async function makeConfigFile (cli) {
     {
       name: 'Api Tokens',
       value: 'api'
+    },
+    {
+      name: 'Plain Token',
+      value: 'token'
     }
   ])
 

--- a/src/Schemes/Token.js
+++ b/src/Schemes/Token.js
@@ -10,6 +10,7 @@
 */
 
 const uuid = require('uuid')
+const _ = require('lodash')
 const ApiScheme = require('./Api')
 const GE = require('@adonisjs/generic-exceptions')
 const CE = require('../Exceptions')
@@ -74,6 +75,49 @@ class TokenScheme extends ApiScheme {
       throw CE.InvalidApiToken.invoke()
     }
     return true
+  }
+
+  /**
+   * List tokens for a given user for the
+   * currently logged in user.
+   *
+   * @method listTokens
+   *
+   * @param  {Object} forUser
+   *
+   * @return {Object}
+   */
+  async listTokens (forUser) {
+    forUser = forUser || this.user
+    if (!forUser) {
+      return this._serializerInstance.fakeResult()
+    }
+
+    const tokens = await this._serializerInstance.listTokens(forUser, 'plain_token')
+
+    /**
+     * We need to pull the `rows` when serializer is lucid, otherwise
+     * we use the array as it is.
+     *
+     * @type {Array}
+     */
+    const tokensArray = _.isArray(tokens) ? tokens : tokens.rows
+
+    /**
+     * If tokens array is empty then return the fake response
+     */
+    if (!_.isArray(tokensArray) || !_.size(tokensArray)) {
+      return this._serializerInstance.fakeResult()
+    }
+
+    /**
+     * Encrypt the tokens
+     */
+    tokensArray.forEach((token) => {
+      token.token = this.Encryption.encrypt(token.token)
+    })
+
+    return tokens
   }
 }
 

--- a/src/Schemes/Token.js
+++ b/src/Schemes/Token.js
@@ -1,0 +1,80 @@
+'use strict'
+
+/*
+ * adonis-auth
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const uuid = require('uuid')
+const ApiScheme = require('./Api')
+const GE = require('@adonisjs/generic-exceptions')
+const CE = require('../Exceptions')
+
+class TokenScheme extends ApiScheme {
+  constructor (Encryption) {
+    super()
+    this.Encryption = Encryption
+  }
+
+  /**
+   * Generates a plain personal API token for a user
+   *
+   * @method generate
+   * @async
+   *
+   * @param  {Object} user
+   *
+   * @return {Object}
+   */
+  async generate (user) {
+    /**
+     * Throw exception when user is not persisted to
+     * database
+     */
+    const userId = user[this.primaryKey]
+    if (!userId) {
+      throw GE.RuntimeException.invoke('Primary key value is missing for user')
+    }
+
+    const token = uuid.v4().replace(/-/g, '')
+    await this._serializerInstance.saveToken(user, token, 'plain_token')
+
+    return { type: 'bearer', token }
+  }
+
+  /**
+   * Check whether the api token has been passed
+   * in the request header and is it valid or
+   * not.
+   *
+   * @method check
+   *
+   * @return {Boolean}
+   */
+  async check () {
+    if (this.user) {
+      return true
+    }
+
+    const token = this.getAuthHeader()
+    if (!token) {
+      throw CE.InvalidApiToken.invoke()
+    }
+
+    this.user = await this._serializerInstance.findByToken(token, 'plain_token')
+
+    /**
+     * Throw exception when user is not found
+     */
+    if (!this.user) {
+      throw CE.InvalidApiToken.invoke()
+    }
+    return true
+  }
+}
+
+module.exports = TokenScheme

--- a/src/Schemes/index.js
+++ b/src/Schemes/index.js
@@ -13,5 +13,6 @@ module.exports = {
   session: require('./Session'),
   basic: require('./BasicAuth'),
   jwt: require('./Jwt'),
-  api: require('./Api')
+  api: require('./Api'),
+  token: require('./Token')
 }

--- a/test/unit/token-scheme.spec.js
+++ b/test/unit/token-scheme.spec.js
@@ -1,0 +1,203 @@
+'use strict'
+
+/*
+ * adonis-auth
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+require('@adonisjs/lucid/lib/iocResolver').setFold(require('@adonisjs/fold'))
+
+const test = require('japa')
+const { ioc } = require('@adonisjs/fold')
+
+const { token: Token } = require('../../src/Schemes')
+const { lucid: LucidSerializer } = require('../../src/Serializers')
+const helpers = require('./helpers')
+const setup = require('./setup')
+
+const Encryption = {
+  encrypt (v) {
+    return v
+  },
+
+  decrypt (v) {
+    return v
+  }
+}
+
+test.group('Schemes - Token Api', (group) => {
+  setup.databaseHook(group)
+  setup.hashHook(group)
+
+  test('generate token for user', async (assert) => {
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    const user = await User.create({ email: 'foo@bar.com', password: 'secret' })
+
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    const tokenPayload = await token.generate(user)
+
+    assert.isDefined(tokenPayload.token)
+    assert.equal(tokenPayload.type, 'bearer')
+  })
+
+  test('verify user token from header', async (assert) => {
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    const user = await User.create({ email: 'foo@bar.com', password: 'secret' })
+    await user.tokens().create({ type: 'plain_token', token: '22', is_revoked: false })
+
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    token.setCtx({
+      request: {
+        header (key) {
+          return `Bearer 22`
+        }
+      }
+    })
+
+    const isLoggedIn = await token.check()
+    assert.isTrue(isLoggedIn)
+    assert.instanceOf(token.user, User)
+  })
+
+  test('throw exception when api token is invalid', async (assert) => {
+    assert.plan(2)
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    await User.create({ email: 'foo@bar.com', password: 'secret' })
+
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    token.setCtx({
+      request: {
+        header (key) {
+          return `Bearer 22`
+        }
+      }
+    })
+
+    try {
+      await token.check()
+    } catch ({ name, message }) {
+      assert.equal(message, 'E_INVALID_API_TOKEN: The api token is missing or invalid')
+      assert.equal(name, 'InvalidApiToken')
+    }
+  })
+
+  test('return user when token is correct', async (assert) => {
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    const user = await User.create({ email: 'foo@bar.com', password: 'secret' })
+    await user.tokens().create({ type: 'plain_token', token: 22, is_revoked: false })
+
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    token.setCtx({
+      request: {
+        header (key) {
+          return `Bearer 22`
+        }
+      }
+    })
+
+    const fetchedUser = await token.getUser()
+    assert.instanceOf(fetchedUser, User)
+  })
+
+  test('read token from request input', async (assert) => {
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    const user = await User.create({ email: 'foo@bar.com', password: 'secret' })
+    await user.tokens().create({ type: 'plain_token', token: 22, is_revoked: false })
+
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    token.setCtx({
+      request: {
+        header () {
+          return null
+        },
+        input () {
+          return '22'
+        }
+      }
+    })
+
+    const isLogged = await token.check()
+    assert.isTrue(isLogged)
+  })
+
+  test('generate token via user credentials', async (assert) => {
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    await User.create({ email: 'foo@bar.com', password: 'secret' })
+
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    const tokenPayload = await token.attempt('foo@bar.com', 'secret')
+
+    assert.isDefined(tokenPayload.token)
+    assert.equal(tokenPayload.type, 'bearer')
+  })
+})

--- a/test/unit/token-scheme.spec.js
+++ b/test/unit/token-scheme.spec.js
@@ -200,4 +200,25 @@ test.group('Schemes - Token Api', (group) => {
     assert.isDefined(tokenPayload.token)
     assert.equal(tokenPayload.type, 'bearer')
   })
+
+  test('return a list of tokens for a given user', async (assert) => {
+    const User = helpers.getUserModel()
+
+    const config = {
+      model: User,
+      uid: 'email',
+      password: 'password'
+    }
+
+    const lucid = new LucidSerializer(ioc.use('Hash'))
+    lucid.setConfig(config)
+
+    const user = await User.create({ email: 'foo@bar.com', password: 'secret' })
+    const token = new Token(Encryption)
+    token.setOptions(config, lucid)
+    const payload = await token.generate(user)
+    const tokensList = await token.listTokens(user)
+    assert.equal(tokensList.size(), 1)
+    assert.equal(tokensList.first().token, payload.token)
+  })
 })


### PR DESCRIPTION
Added a Plain API token scheme, I wanted to make modifications to ApiScheme by adding a `auth.js` config such as `{ scheme: 'api', plain: true }` but I guess to create a new Scheme would be ok to not alter existing. This scheme extends `ApiScheme`

If I do miss or bad commit, please let me know, this is my first contribution to any repo on github.