### PR TITLE
Fix JWT token revoking

### DIFF
--- a/src/Schemes/Jwt.js
+++ b/src/Schemes/Jwt.js
@@ -328,7 +328,7 @@ class JwtScheme extends BaseScheme {
     if (!token.refreshToken) {
       token.refreshToken = refreshToken
     } else {
-      await this._serializerInstance.revokeTokens(user, [refreshToken])
+      await this._serializerInstance.revokeTokens(user, [plainRefreshToken])
     }
 
     return token

--- a/test/unit/jwt-scheme.spec.js
+++ b/test/unit/jwt-scheme.spec.js
@@ -530,7 +530,7 @@ test.group('Schemes - Jwt', (group) => {
     const jwt = new Jwt(Encryption)
     jwt.setOptions(config, lucid)
 
-    const { token, refreshToken } = await jwt.newRefreshToken().generateForRefreshToken('20')
+    const { token, refreshToken } = await jwt.newRefreshToken().generateForRefreshToken(Encryption.encrypt('20'))
     assert.isDefined(token)
 
     const payload = await verifyToken(token)

--- a/test/unit/lucid-serializer.spec.js
+++ b/test/unit/lucid-serializer.spec.js
@@ -164,7 +164,7 @@ test.group('Serializers - Lucid', (group) => {
     await lucid.findByToken('20', 'remember_token')
     assert.equal(
       authQuery.sql,
-      'select * from `users` where exists (select * from `tokens` where `token` = ? and `type` = ? and `is_revoked` = ? and users.id = tokens.user_id) limit ?'
+      'select * from `users` where exists (select * from `tokens` where `token` = ? and `type` = ? and `is_revoked` = ? and `users`.`id` = `tokens`.`user_id`) limit ?'
     )
     assert.deepEqual(authQuery.bindings, ['20', 'remember_token', false, 1])
   })

--- a/test/unit/lucid-serializer.spec.js
+++ b/test/unit/lucid-serializer.spec.js
@@ -164,7 +164,7 @@ test.group('Serializers - Lucid', (group) => {
     await lucid.findByToken('20', 'remember_token')
     assert.equal(
       authQuery.sql,
-      'select * from `users` where exists (select * from `tokens` where `token` = ? and `type` = ? and `is_revoked` = ? and `users`.`id` = `tokens`.`user_id`) limit ?'
+      'select * from `users` where exists (select * from `tokens` where `token` = ? and `type` = ? and `is_revoked` = ? and users.id = tokens.user_id) limit ?'
     )
     assert.deepEqual(authQuery.bindings, ['20', 'remember_token', false, 1])
   })


### PR DESCRIPTION
Revoke plain version of the token instead of encrypted one.

Currently revoking doesn't work.