### PR TITLE
store authenticator on session and cookie

### DIFF
--- a/src/Auth/index.js
+++ b/src/Auth/index.js
@@ -90,7 +90,7 @@ class Auth {
     }
 
     const config = this.Config.get(`auth.${name}`)
-
+    config.authenticator = name
     /**
      * Throws exception when config is defined or missing
      */

--- a/src/Schemes/Base.js
+++ b/src/Schemes/Base.js
@@ -41,6 +41,17 @@ class BaseScheme {
   }
 
   /**
+   * The authenticator field. Get name of the current authenticator
+   *
+   * @attribute authenticator
+   * @readOnly
+   * @type {String}
+   */
+  get authenticator () {
+    return this._config.authenticator
+  }
+
+  /**
    * The password field name. Reads the `password` from the config object
    *
    * @attribute passwordField

--- a/src/Schemes/Session.js
+++ b/src/Schemes/Session.js
@@ -72,14 +72,20 @@ class SessionScheme extends BaseScheme {
    * @private
    */
   _setSession (primaryKeyValue, rememberToken, duration) {
-    this._ctx.session.put(this.sessionKey, primaryKeyValue)
+    this._ctx.session.put(this.sessionKey, {
+      authenticator: this.authenticator,
+      primaryKeyValue
+    })
 
     /**
      * Set remember me cookie when token and duration is
      * defined
      */
     if (rememberToken && duration) {
-      this._ctx.response.cookie(this.rememberTokenKey, rememberToken, {
+      this._ctx.response.cookie(this.rememberTokenKey, {
+        authenticator: this.authenticator,
+        rememberToken
+      }, {
         expires: new Date(Date.now() + duration)
       })
     }
@@ -304,8 +310,8 @@ class SessionScheme extends BaseScheme {
      * Look for user only when there is a session
      * cookie
      */
-    if (sessionValue) {
-      this.user = await this._serializerInstance.findById(sessionValue)
+    if (sessionValue && sessionValue.authenticator === this.authenticator) {
+      this.user = await this._serializerInstance.findById(sessionValue.primaryKeyValue)
     }
 
     /**
@@ -319,8 +325,8 @@ class SessionScheme extends BaseScheme {
      * Attempt to login the user when remeber me
      * token exists
      */
-    if (rememberMeToken) {
-      const user = await this._serializerInstance.findByToken(rememberMeToken, 'remember_token')
+    if (rememberMeToken && rememberMeToken.authenticator === this.authenticator) {
+      const user = await this._serializerInstance.findByToken(rememberMeToken.rememberToken, 'remember_token')
       if (user) {
         await this.login(user)
         return true


### PR DESCRIPTION
My issue: #119 

The problem: actually I want to have couple authenticator with same session scheme for auth.
there is some problem because of you only store the primary key on session and cookie so when I logged in as admin the `auth.check()` return true work for couple authenticator.

My solution: so I try to store authenticator name on the alongside primary key in session and cookie at login time then I check authenticator name in session or cookie with current auth authenticator name for check auth